### PR TITLE
Feat/populate components

### DIFF
--- a/src/api/blog-entry-page/controllers/blog-entry-page.js
+++ b/src/api/blog-entry-page/controllers/blog-entry-page.js
@@ -6,4 +6,23 @@
 
 const { createCoreController } = require('@strapi/strapi').factories;
 
-module.exports = createCoreController('api::blog-entry-page.blog-entry-page');
+module.exports = createCoreController('api::blog-entry-page.blog-entry-page',  ({ strapi }) => ({
+  async find(ctx) {
+    const { data, meta } = await super.find(ctx);
+    const components = await Promise.all(data.attributes.sections.map(async section => {
+      const component = await strapi.entityService.findOne(section.__component, section.id, { populate: '*' })
+      // check for repeatable components to bring all data
+      if (section.__component === 'sections.hero-slider') {
+        const slides = await Promise.all(component.slide.map(async slide => {
+          const newslide = await strapi.entityService.findOne('sections.hero', slide.id, { populate: '*' })
+          return newslide
+        }))
+        component.slide = slides
+      }
+      return component
+    }))
+    data.attributes.sections = components
+    return { data, meta };
+  },
+}));
+

--- a/src/api/blog-page/controllers/blog-page.js
+++ b/src/api/blog-page/controllers/blog-page.js
@@ -6,4 +6,23 @@
 
 const { createCoreController } = require('@strapi/strapi').factories;
 
-module.exports = createCoreController('api::blog-page.blog-page');
+module.exports = createCoreController('api::blog-page.blog-page',  ({ strapi }) => ({
+  async find(ctx) {
+    const { data, meta } = await super.find(ctx);
+    const components = await Promise.all(data.attributes.sections.map(async section => {
+      const component = await strapi.entityService.findOne(section.__component, section.id, { populate: '*' })
+      // check for repeatable components to bring all data
+      if (section.__component === 'sections.hero-slider') {
+        const slides = await Promise.all(component.slide.map(async slide => {
+          const newslide = await strapi.entityService.findOne('sections.hero', slide.id, { populate: '*' })
+          return newslide
+        }))
+        component.slide = slides
+      }
+      return component
+    }))
+    data.attributes.sections = components
+    return { data, meta };
+  },
+}));
+

--- a/src/api/home-page/controllers/home-page.js
+++ b/src/api/home-page/controllers/home-page.js
@@ -8,35 +8,19 @@ const { createCoreController } = require('@strapi/strapi').factories;
 
 module.exports = createCoreController('api::home-page.home-page',  ({ strapi }) => ({
   async find(ctx) {
-    console.log(ctx);
-    // some custom logic here
-    // ctx.query = { ...ctx.query, local: 'en' };
-    
-    // Calling the default core action
     const { data, meta } = await super.find(ctx);
-    console.log(data.attributes.sections);
-    // console.log(meta);
     const components = await Promise.all(data.attributes.sections.map(async section => {
       const component = await strapi.entityService.findOne(section.__component, section.id, { populate: '*' })
       if (section.__component === 'sections.hero-slider') {
         const slides = await Promise.all(component.slide.map(async slide => {
-          console.log('slide: ', slide);
           const newslide = await strapi.entityService.findOne('sections.hero', slide.id, { populate: '*' })
-          console.log('newslide: ', newslide);
           return newslide
         }))
-        console.log('slides: ', slides);
         component.slide = slides
       }
-      console.log('component: ', component);
       return component
     }))
-    console.log('components: ', components);
     data.attributes.sections = components
-
-    // some more custom logic
-    // meta.date = Date.now();
-
     return { data, meta };
   },
 }));

--- a/src/api/home-page/controllers/home-page.js
+++ b/src/api/home-page/controllers/home-page.js
@@ -11,6 +11,7 @@ module.exports = createCoreController('api::home-page.home-page',  ({ strapi }) 
     const { data, meta } = await super.find(ctx);
     const components = await Promise.all(data.attributes.sections.map(async section => {
       const component = await strapi.entityService.findOne(section.__component, section.id, { populate: '*' })
+      // check for repeatable components to bring all data
       if (section.__component === 'sections.hero-slider') {
         const slides = await Promise.all(component.slide.map(async slide => {
           const newslide = await strapi.entityService.findOne('sections.hero', slide.id, { populate: '*' })

--- a/src/api/home-page/controllers/home-page.js
+++ b/src/api/home-page/controllers/home-page.js
@@ -6,4 +6,37 @@
 
 const { createCoreController } = require('@strapi/strapi').factories;
 
-module.exports = createCoreController('api::home-page.home-page');
+module.exports = createCoreController('api::home-page.home-page',  ({ strapi }) => ({
+  async find(ctx) {
+    console.log(ctx);
+    // some custom logic here
+    // ctx.query = { ...ctx.query, local: 'en' };
+    
+    // Calling the default core action
+    const { data, meta } = await super.find(ctx);
+    console.log(data.attributes.sections);
+    // console.log(meta);
+    const components = await Promise.all(data.attributes.sections.map(async section => {
+      const component = await strapi.entityService.findOne(section.__component, section.id, { populate: '*' })
+      if (section.__component === 'sections.hero-slider') {
+        const slides = await Promise.all(component.slide.map(async slide => {
+          console.log('slide: ', slide);
+          const newslide = await strapi.entityService.findOne('sections.hero', slide.id, { populate: '*' })
+          console.log('newslide: ', newslide);
+          return newslide
+        }))
+        console.log('slides: ', slides);
+        component.slide = slides
+      }
+      console.log('component: ', component);
+      return component
+    }))
+    console.log('components: ', components);
+    data.attributes.sections = components
+
+    // some more custom logic
+    // meta.date = Date.now();
+
+    return { data, meta };
+  },
+}));

--- a/src/api/page/controllers/page.js
+++ b/src/api/page/controllers/page.js
@@ -6,4 +6,44 @@
 
 const { createCoreController } = require('@strapi/strapi').factories;
 
-module.exports = createCoreController('api::page.page');
+module.exports = createCoreController('api::page.page',  ({ strapi }) => ({
+  async findOne(ctx) {
+    const { data, meta } = await super.find(ctx);
+    const components = await Promise.all(data.attributes.sections.map(async section => {
+      const component = await strapi.entityService.findOne(section.__component, section.id, { populate: '*' })
+      // check for repeatable components to bring all data
+      if (section.__component === 'sections.hero-slider') {
+        const slides = await Promise.all(component.slide.map(async slide => {
+          const newslide = await strapi.entityService.findOne('sections.hero', slide.id, { populate: '*' })
+          return newslide
+        }))
+        component.slide = slides
+      }
+      return component
+    }))
+    data.attributes.sections = components
+    return { data, meta };
+  },
+  async find(ctx) {
+    const { data, meta } = await super.find(ctx);
+    const newdata = Promise.all(data.map(async page => {
+
+      const components = await Promise.all(page.attributes.sections.map(async section => {
+        const component = await strapi.entityService.findOne(section.__component, section.id, { populate: '*' })
+        // check for repeatable components to bring all data
+        if (section.__component === 'sections.hero-slider') {
+          const slides = await Promise.all(component.slide.map(async slide => {
+            const newslide = await strapi.entityService.findOne('sections.hero', slide.id, { populate: '*' })
+            return await newslide
+          }))
+          component.slide = slides
+        }
+        return await component
+      }))
+      page.attributes.sections = components
+      return page
+    }))
+    return { data: await newdata, meta };
+  },
+}));
+


### PR DESCRIPTION
ISSUE:
- Components are not being populated with images or when they are repeatable

SOLUTION:
- Modified find method for Home, Blog, Blog entry.
- Modified find and findOne methods for Pages
- Both changes fetch every component and in case of hero slider fetch every slide, to fetch images (disclaimer: if new components are added we need to test this feat to fetch its components in case is a repeatable component

TEST:
- CO to this branch in local
- run project
- use insomnia to consume rest api in any of these `/home-page/` `/blog-page/` `/blog-entry-page/` `/pages/` `/pages/:id`
- Enjoy 🍶 