### PR TITLE
Podcast Episodes Collection Type

### DIFF
--- a/src/api/podcast-episode/content-types/podcast-episode/schema.json
+++ b/src/api/podcast-episode/content-types/podcast-episode/schema.json
@@ -1,0 +1,19 @@
+{
+  "kind": "collectionType",
+  "collectionName": "podcast_episodes",
+  "info": {
+    "singularName": "podcast-episode",
+    "pluralName": "podcast-episodes",
+    "displayName": "Podcast Episode"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "episodeId": {
+      "type": "uid",
+      "required": true
+    }
+  }
+}

--- a/src/api/podcast-episode/controllers/podcast-episode.js
+++ b/src/api/podcast-episode/controllers/podcast-episode.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * podcast-episode controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::podcast-episode.podcast-episode');

--- a/src/api/podcast-episode/routes/podcast-episode.js
+++ b/src/api/podcast-episode/routes/podcast-episode.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * podcast-episode router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::podcast-episode.podcast-episode');

--- a/src/api/podcast-episode/services/podcast-episode.js
+++ b/src/api/podcast-episode/services/podcast-episode.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * podcast-episode service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::podcast-episode.podcast-episode');

--- a/src/components/sections/listconfig.json
+++ b/src/components/sections/listconfig.json
@@ -20,7 +20,8 @@
       "enum": [
         "blogentries",
         "pages",
-        "faq"
+        "faq",
+        "podcastEpisodes",
       ]
     },
     "sortdate": {


### PR DESCRIPTION
## Issue
Create a collection type to store Spotify podcast episodes. As the frontend uses an `iframe` to display the player, only the episode id is needed.

## Solution
- [X] Created Podcast Episode collection type.
- [X] Added `podcastEpisodes` at `listconfig` enum.


Query example:
```
query PodcastEpisodes {
  podcastEpisodes {
    data {
      attributes {
        episodeId
      }
    }
  }
}
```

Query response:
```
{
  "data": {
    "podcastEpisodes": {
      "data": [
        {
          "attributes": {
            "episodeId": "4Ye5BzFTgw43A9KvbItiJF"
          }
        }
      ]
    }
  }
}
```