### PR TITLE
[DEV-5064] Add StatisticCard & Slider fields <Strapi Types>

### DIFF
--- a/src/components/sections/hero-slider.json
+++ b/src/components/sections/hero-slider.json
@@ -10,6 +10,9 @@
       "type": "component",
       "repeatable": true,
       "component": "sections.hero"
+    },
+    "height": {
+      "type": "integer"
     }
   }
 }

--- a/src/components/sections/statistics-card.json
+++ b/src/components/sections/statistics-card.json
@@ -39,6 +39,17 @@
     },
     "icon": {
       "type": "string"
+    },
+    "border": {
+      "type": "boolean"
+    },
+    "color": {
+      "type": "customField",
+      "regex": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+      "customField": "plugin::color-picker.color"
+    },
+    "container": {
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
### ISSUE
Hero Slider & Statistic Card component require new fields in order to be able to be set at a component level in the Portalverse app. It is necessary to update those component fields in order to achieve that.

### SOLUTION
- [X] Added height field to hero slider 48f21ee.
- [X] Added border, color & container fields to statistic card f573f26.

### HOW TO TEST
1. Checkout to PR.
2. Run application by running command `pm2 start ecosystem.config.js` in the project terminal.
2.1 If not working, try by running `pm2 delete all`, then repeating the command from step 2.
3. Go to Hero Slider `/admin/plugins/content-type-builder/component-categories/sections/sections.hero-slider` component in collection types.
4. Go to Statistic Card `/admin/plugins/content-type-builder/component-categories/sections/sections.statistics-card` component too.
5. Validate fields & their types.
6. Enjoy 🍊.

Task [URL](https://dev.azure.com/lottusAdmin/Portalverse/_workitems/edit/5064).