### PR TITLE
[DEV-5919] Educational Offering Model

### DIFF
--- a/src/api/educational-offering/content-types/educational-offering/schema.json
+++ b/src/api/educational-offering/content-types/educational-offering/schema.json
@@ -1,0 +1,22 @@
+{
+  "kind": "singleType",
+  "collectionName": "educational_offerings",
+  "info": {
+    "singularName": "educational-offering",
+    "pluralName": "educational-offerings",
+    "displayName": "Educational Offering",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "levelsConfig": {
+      "displayName": "LevelPageConfig",
+      "type": "component",
+      "repeatable": true,
+      "component": "programs.level-page-config"
+    }
+  }
+}

--- a/src/api/educational-offering/controllers/educational-offering.js
+++ b/src/api/educational-offering/controllers/educational-offering.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * educational-offering controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::educational-offering.educational-offering');

--- a/src/api/educational-offering/routes/educational-offering.js
+++ b/src/api/educational-offering/routes/educational-offering.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * educational-offering router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::educational-offering.educational-offering');

--- a/src/api/educational-offering/services/educational-offering.js
+++ b/src/api/educational-offering/services/educational-offering.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * educational-offering service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::educational-offering.educational-offering');

--- a/src/components/programs/level-page-config.json
+++ b/src/components/programs/level-page-config.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_programs_level_page_configs",
+  "info": {
+    "displayName": "LevelPageConfig"
+  },
+  "options": {},
+  "attributes": {
+    "level": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::level.level"
+    },
+    "slug": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
## Issue
Create a Single Type model to store configuration related to program-specific pages.

```
query EducationalOffering {
  educationalOffering {
    data {
      attributes {
        levelsConfig {
          slug
          level {
            data {
              attributes {
                title
              }
            }
          }
        }
      }
    }
  }
}