### PR TITLE
[DEV-6026] BlogPosts component model

### DIFF
--- a/src/api/page/content-types/page/schema.json
+++ b/src/api/page/content-types/page/schema.json
@@ -43,7 +43,8 @@
         "sections.form-video",
         "sections.programs-filter",
         "sections.cont-ed-programs",
-        "sections.accordion"
+        "sections.accordion",
+        "sections.blog-posts"
       ],
       "required": true
     },

--- a/src/components/sections/blog-posts.json
+++ b/src/components/sections/blog-posts.json
@@ -1,0 +1,35 @@
+{
+  "collectionName": "components_sections_blog_posts",
+  "info": {
+    "displayName": "BlogPosts"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "text"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "maxEntries": {
+      "type": "integer",
+      "required": true
+    },
+    "category": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::category.category"
+    },
+    "sort": {
+      "type": "enumeration",
+      "enum": [
+        "latest",
+        "earliest"
+      ],
+      "default": "latest"
+    }
+  }
+}


### PR DESCRIPTION
## Issue
Currently, the `Listconfig` component is being used to retrieve both blog entries as well as podcast items. The component currently retrieves a specified amount of items without filtering. However, for blog entries, and specifically for the `/nosotros/internacionalizacion` page, we now need to retrieve blog posts based on a given category, which is not currently possible with the `Listconfig` component. Instead of extending this component that serves multiple purposes (which may be confusing for the end user), we created a new component with configuration parameters specific to blog entries, including the category filter.

## Solution
- [X] Created `BlogPosts` component model.
- [X] Added `BlogPosts` component to `page` dynamic zone.

Query:
```
... on ComponentSectionsBlogPosts {
  title
  subtitle
  description
  maxEntries
  sort
  category {
    data {
      attributes {
        title
      }
    }
  }
}