### PR TITLE
[ENG-702] Static Contents Model

### DIFF
--- a/src/api/static-content/content-types/static-content/schema.json
+++ b/src/api/static-content/content-types/static-content/schema.json
@@ -1,0 +1,33 @@
+{
+  "kind": "collectionType",
+  "collectionName": "static_contents",
+  "info": {
+    "singularName": "static-content",
+    "pluralName": "static-contents",
+    "displayName": "StaticContent",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "path": {
+      "type": "string",
+      "required": true
+    },
+    "content": {
+      "type": "text",
+      "required": false
+    },
+    "format": {
+      "type": "enumeration",
+      "enum": [
+        "json",
+        "ts"
+      ],
+      "required": true,
+      "default": "json"
+    }
+  }
+}

--- a/src/api/static-content/controllers/static-content.js
+++ b/src/api/static-content/controllers/static-content.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * static-content controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::static-content.static-content');

--- a/src/api/static-content/routes/static-content.js
+++ b/src/api/static-content/routes/static-content.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * static-content router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::static-content.static-content');

--- a/src/api/static-content/services/static-content.js
+++ b/src/api/static-content/services/static-content.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * static-content service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::static-content.static-content');


### PR DESCRIPTION
### ISSUE

Created collection type model called Static Content which enables to create entries for portalverse repo's static contents such as JSON pages, routes, as well as other files. The field of the StaticContent model are:
- format (json, ts).
- content (the content of the file, whether it's a json or typescript file).
- path (which defines the route where the file is going to be placed at the pre-build process in the portalverse project).

### SOLUTION
- [X] Created static content model 7d941a0..

Query example:
```
query StaticContents {
  staticContents(publicationState: LIVE, pagination: { start: 0, limit: -1 }) {
  	data {
      attributes {
        format
        content
        path
      }
    }
  }
}