### PR TITLE
[ENG-729] Update linkUrl field type in Strapi card component

### DIFF
--- a/src/components/sections/card.json
+++ b/src/components/sections/card.json
@@ -27,7 +27,7 @@
       "type": "string"
     },
     "linkUrl": {
-      "type": "string"
+      "type": "text"
     },
     "image": {
       "type": "media",


### PR DESCRIPTION
### ISSUE
Currently linkUrl field in Card components doesn't support long URL strings. This is because it is set as a `string` type, which only allows 255 characters long. However, there are cases in which URLs are +255 long. It is necessary to update the type of this field to `text`, which allows an undefined length of characters.

### SOLUTION
- [X] Updated linkUrl type in card component 2fc4ade.
