### PR TITLE
[ENG-913] Add text field for modalities tabs in strapi

### DIFF
--- a/src/components/programs/modality-feature.json
+++ b/src/components/programs/modality-feature.json
@@ -11,6 +11,9 @@
       "relation": "oneToOne",
       "target": "api::modality.modality"
     },
+    "labelModality": {
+      "type": "string"
+    },
     "admissionProfile": {
       "type": "richtext"
     },


### PR DESCRIPTION
The labelModality field is added to add text that is required to the tabs in the front, if it does not exist, the name of the modality must be placed