### PR TITLE
[ENG-754] Program Accordeon Component for Campus detail page

### DIFF
--- a/src/api/page/content-types/page/schema.json
+++ b/src/api/page/content-types/page/schema.json
@@ -31,8 +31,10 @@
         "sections.blog-posts-podcast",
         "sections.card-list",
         "sections.contact-target-list",
+        "sections.container-outstanding-list",
         "sections.cont-ed-programs",
         "sections.faq-section",
+        "sections.form-container",
         "sections.form-video",
         "sections.listconfig",
         "sections.link-list",
@@ -42,14 +44,13 @@
         "sections.statistics-card-list",
         "sections.overlay-card-list",
         "sections.rich-text-image",
+        "sections.rich-text-video",
         "sections.hero-slider",
         "sections.text-content",
-        "sections.rich-text-video",
-        "sections.container-outstanding-list",
         "sections.google-map",
         "sections.knowledge-area-filter",
         "sections.modality-filter",
-        "sections.form-container"
+        "sections.program-accordion-list"
       ],
       "required": true
     },

--- a/src/components/programs/program-accordion-item.json
+++ b/src/components/programs/program-accordion-item.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_programs_program_accordion_items",
+  "info": {
+    "displayName": "ProgramAccordionItem",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "label": {
+      "type": "string"
+    },
+    "level": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::level.level"
+    },
+    "campus": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::campus.campus"
+    },
+    "modality": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::modality.modality"
+    }
+  }
+}

--- a/src/components/sections/program-accordion-list.json
+++ b/src/components/sections/program-accordion-list.json
@@ -1,0 +1,18 @@
+{
+  "collectionName": "components_sections_program_accordion_lists",
+  "info": {
+    "displayName": "ProgramAccordionList",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "programAccordionItems": {
+      "type": "component",
+      "repeatable": true,
+      "component": "programs.program-accordion-item"
+    }
+  }
+}


### PR DESCRIPTION
### Issue
Created component + section so a new section can be added to the pages collection type. This feature enables adding the representation of programs (offer) filtered by level, campus and/or modality on pages. It is primarily implemented for the campus detail page. Which displays an accordion element with the programs offer segmented by campus, level & modality. 

### Solution
- [X] Created ProgramAccordtionItem component c04dec3.
- [X] Created ProgramAccordionList component 22634a8.
- [X] Added ProgramAccordionList to page sections 4560cbc.