### PR TITLE
[ENG-1310] Add title to Google Maps Section <Strapi>

### DIFF
--- a/src/components/sections/google-map.json
+++ b/src/components/sections/google-map.json
@@ -6,6 +6,9 @@
   },
   "options": {},
   "attributes": {
+    "title": {
+      "type": "string"
+    },
     "src": {
       "type": "text",
       "required": true,


### PR DESCRIPTION
### ISSUE
It's required to add a title to the GoogleMap Section in order to not have to use a TextContent above this section to provide context for user about the section's content/title.

### SOLUTION
- [X] Added title to Google map section 2461e25.
