### PR TITLE
create model CardsDetailContent section

### DIFF
--- a/src/api/page/content-types/page/schema.json
+++ b/src/api/page/content-types/page/schema.json
@@ -57,7 +57,8 @@
         "sections.modality-filter",
         "sections.program-accordion-list",
         "sections.rockstar-info-list",
-        "sections.videos"
+        "sections.videos",
+        "sections.cards-detail-content"
       ],
       "required": true
     },

--- a/src/components/sections/cards-detail-content.json
+++ b/src/components/sections/cards-detail-content.json
@@ -1,0 +1,34 @@
+{
+  "collectionName": "components_sections_cards_detail_contents",
+  "info": {
+    "displayName": "CardsDetailContent",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "links": {
+      "type": "component",
+      "repeatable": true,
+      "component": "sections.link"
+    },
+    "cards": {
+      "type": "component",
+      "repeatable": true,
+      "component": "sections.card"
+    },
+    "textPosition": {
+      "type": "enumeration",
+      "enum": [
+        "right",
+        "left"
+      ],
+      "default": "left"
+    }
+  }
+}


### PR DESCRIPTION
Issue
Develop a model for the CardsDetailContent section

Solution
[X] create model CardsDetailContent section 1c9f879

1. Testing
2. Checkout to PR branch, run yarn & yarn dev.
3. Open strapi in the http://localhost:1338/admin
4. Go to content-manager/collectionType/page.
5. Create a new page
6. Go to create new section and select CardDetailContent
7. Fill the fields
8. Save changes
9. Visit the page you created
10. Enjoy. 🌮